### PR TITLE
Correct typos in method names

### DIFF
--- a/1.1_Introduction_to_Simulation.md
+++ b/1.1_Introduction_to_Simulation.md
@@ -197,9 +197,9 @@ W=writing task, P=programming task
 
    Define a `ServicePoint` class, associated with a queue (`LinkedList`), that picks customers from the queue (by the queue's normal order) and serves them one by one.
 
-   To implement the queue, use the Java `LinkedList` class as in the previous task. Define the methods void `addToQueueue(Customer a)` and `Customer removeFromQueueue()` in the `ServicePoint` class.
+   To implement the queue, use the Java `LinkedList` class as in the previous task. Define the methods void `addToQueue(Customer a)` and `Customer removeFromQueue()` in the `ServicePoint` class.
 
-   Define also a method called `serve()` for the `ServicePoint` class that picks all the clients by turns from the queue using the aforementioned `Customer removeFromQueueue()` method. After retrieving the customer from the queue, we simulate the service task (in the `serve` method) by delaying the execution of the code (before calling the `Customer removeFromQueueue()` method again) by calling the `Thread.sleep(sleeptime)` method. The service time = sleeptime and is computed in the program, e.g., with the `Math.random()` method.
+   Define also a method called `serve()` for the `ServicePoint` class that picks all the clients by turns from the queue using the aforementioned `Customer removeFromQueue()` method. After retrieving the customer from the queue, we simulate the service task (in the `serve` method) by delaying the execution of the code (before calling the `Customer removeFromQueue()` method again) by calling the `Thread.sleep(sleeptime)` method. The service time = sleeptime and is computed in the program, e.g., with the `Math.random()` method.
 
    As soon as the customer is served, the `serve` method takes the next customer in the queue. When the queue is empty, the execution of the `serve` method terminates.
 


### PR DESCRIPTION
In the question number 5 under the Orientation Assignment1 chapter, it seems there are typos in the following method names:`addToQueueue` and `removeFromQueueue` 

Those names are changed to `addToQueue` and `removeFromQueue` in this PR. 